### PR TITLE
Add optional siteid query parameter to v1 projects-info API

### DIFF
--- a/v1/api/swagger/components/parameters/SiteID.yaml
+++ b/v1/api/swagger/components/parameters/SiteID.yaml
@@ -1,0 +1,7 @@
+name: siteid
+in: query
+description: GreenLake site ID
+required: false
+schema:
+  type: string
+example: 95688cf9-82ff-4e32-80fc-2b0b41648dab

--- a/v1/api/swagger/paths/projects-info.yaml
+++ b/v1/api/swagger/paths/projects-info.yaml
@@ -21,6 +21,7 @@ get:
   parameters:
     - $ref: ../components/parameters/Space.yaml
     - $ref: ../components/parameters/SpaceID.yaml
+    - $ref: ../components/parameters/SiteID.yaml    
   responses:
     '200':
       description: success

--- a/v1/pkg/client/api/openapi.yaml
+++ b/v1/pkg/client/api/openapi.yaml
@@ -408,6 +408,13 @@ paths:
         name: spaceid
         schema:
           type: string
+      - description: GreenLake site ID
+        example: 95688cf9-82ff-4e32-80fc-2b0b41648dab
+        in: query
+        name: siteid
+        required: false
+        schema:
+          type: string
       responses:
         "200":
           content:

--- a/v1/pkg/client/api_projects_info.go
+++ b/v1/pkg/client/api_projects_info.go
@@ -32,6 +32,7 @@ type ProjectsInfoApiService service
 type ProjectsInfoApiListOpts struct {
     Space optional.String
     Spaceid optional.String
+    Siteid optional.String
 }
 
 /*
@@ -41,6 +42,7 @@ Returns an object with information on projects, machine sizes, and volume flavor
  * @param optional nil or *ProjectsInfoApiListOpts - Optional Parameters:
  * @param "Space" (optional.String) -  GreenLake space name
  * @param "Spaceid" (optional.String) -  GreenLake space ID
+ * @param "Siteid" (optional.String) -  GreenLake site ID
 @return ProjectsInfo
 */
 func (a *ProjectsInfoApiService) List(ctx _context.Context, localVarOptionals *ProjectsInfoApiListOpts) (ProjectsInfo, *_nethttp.Response, error) {
@@ -59,6 +61,9 @@ func (a *ProjectsInfoApiService) List(ctx _context.Context, localVarOptionals *P
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 
+	if localVarOptionals != nil && localVarOptionals.Siteid.IsSet() {
+		localVarQueryParams.Add("siteid", parameterToString(localVarOptionals.Siteid.Value(), ""))
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/v1/pkg/client/docs/ProjectsInfoApi.md
+++ b/v1/pkg/client/docs/ProjectsInfoApi.md
@@ -33,6 +33,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **space** | **optional.String**| GreenLake space name | 
  **spaceid** | **optional.String**| GreenLake space ID | 
+ **siteid** | **optional.String**| GreenLake site ID | 
 
 ### Return type
 

--- a/v1/pkg/client/interface_projects_info.go
+++ b/v1/pkg/client/interface_projects_info.go
@@ -18,6 +18,7 @@ type ProjectsInfoAPI interface {
 	    * @param optional nil or *ProjectsInfoApiListOpts - Optional Parameters:
 	    * @param "Space" (optional.String) -  GreenLake space name
 	    * @param "Spaceid" (optional.String) -  GreenLake space ID
+	    * @param "Siteid" (optional.String) -  GreenLake site ID
 	   @return ProjectsInfo
 	*/
 	List(ctx _context.Context, localVarOptionals *ProjectsInfoApiListOpts) (ProjectsInfo, *_nethttp.Response, error)


### PR DESCRIPTION
Add optional siteid query parameter to v1 projects-info API

Rally: US35938

2 updated files for review are:
v1/api/swagger/paths/projects-info.yaml
v1/api/swagger/components/parameters/SiteID.yaml

All other files are auto generated.