### PR TITLE
Changed status code to 204 when there is no response

### DIFF
--- a/v2alpha1/api/swagger/components/schemas/ComputeGroupInfo.yaml
+++ b/v2alpha1/api/swagger/components/schemas/ComputeGroupInfo.yaml
@@ -15,8 +15,8 @@ properties:
   status:
     type: string
     enum:
-      - Enable
-      - Disable
+      - Enabled
+      - Disabled
   numNetworks:
     type: integer
     description: Number of networks in compute group

--- a/v2alpha1/api/swagger/paths/allocation@server.yaml
+++ b/v2alpha1/api/swagger/paths/allocation@server.yaml
@@ -6,7 +6,7 @@ get:
   operationId: allocation_getBySite
   parameters:
     - name: siteID
-      in: path
+      in: query
       description: site ID
       required: false
       schema:

--- a/v2alpha1/api/swagger/paths/computegroups.yaml
+++ b/v2alpha1/api/swagger/paths/computegroups.yaml
@@ -1,6 +1,6 @@
 get:
   tags:
-    - compute groups
+    - computegroups
   summary: List of all compute groups within an organization or cluster
   description: >-
     Returns an array of all compute group objects that have been created. This

--- a/v2alpha1/api/swagger/paths/computegroups@{groupId}.yaml
+++ b/v2alpha1/api/swagger/paths/computegroups@{groupId}.yaml
@@ -99,8 +99,8 @@ delete:
       schema:
         type: string
   responses:
-    '200':
-      description: success
+    '204':
+      description: no content
     '400':
       $ref: ../components/responses/InvalidContent.yaml
     '401':

--- a/v2alpha1/api/swagger/paths/hosts@{hostId}.yaml
+++ b/v2alpha1/api/swagger/paths/hosts@{hostId}.yaml
@@ -89,8 +89,8 @@ delete:
       schema:
         type: string
   responses:
-    '200':
-      description: success
+    '204':
+      description: no content
     '400':
       $ref: ../components/responses/InvalidContent.yaml
     '401':

--- a/v2alpha1/api/swagger/paths/networks@{networkId}.yaml
+++ b/v2alpha1/api/swagger/paths/networks@{networkId}.yaml
@@ -80,8 +80,8 @@ delete:
       schema:
         type: string
   responses:
-    '200':
-      description: success
+    '204':
+      description: no content
     '400':
       $ref: ../components/responses/InvalidContent.yaml
     '401':

--- a/v2alpha1/api/swagger/paths/sshkeys@{sshkeyId}.yaml
+++ b/v2alpha1/api/swagger/paths/sshkeys@{sshkeyId}.yaml
@@ -80,8 +80,8 @@ delete:
       schema:
         type: string
   responses:
-    '200':
-      description: success
+    '204':
+      description: no content
     '400':
       $ref: ../components/responses/InvalidContent.yaml
     '401':

--- a/v2alpha1/api/swagger/paths/volume-attachments@{attachmentId}.yaml
+++ b/v2alpha1/api/swagger/paths/volume-attachments@{attachmentId}.yaml
@@ -41,8 +41,8 @@ delete:
       schema:
         type: string
   responses:
-    '200':
-      description: success
+    '204':
+      description: no content
     '400':
       $ref: ../components/responses/InvalidContent.yaml
     '401':

--- a/v2alpha1/api/swagger/paths/volumes@{volumeId}.yaml
+++ b/v2alpha1/api/swagger/paths/volumes@{volumeId}.yaml
@@ -73,8 +73,8 @@ delete:
       schema:
         type: string
   responses:
-    '200':
-      description: success
+    '204':
+      description: no content
     '400':
       $ref: ../components/responses/InvalidContent.yaml
     '401':

--- a/v2alpha1/api/swagger/paths/volumes@{volumeId}@detach.yaml
+++ b/v2alpha1/api/swagger/paths/volumes@{volumeId}@detach.yaml
@@ -27,8 +27,8 @@ post:
         schema:
           $ref: ../components/schemas/VolumeAttachHostUUID.yaml
   responses:
-    '200':
-      description: success
+    '204':
+      description: no content
     '400':
       $ref: ../components/responses/InvalidContent.yaml
     '401':


### PR DESCRIPTION
Per standards, Status codes other than 204 and 304 should contain a JSON response.
So updated various resource delete & VA detach definitions( which do not return response) to have 204 as the success status code.
Addresses issue#17 here https://rndwiki-pro.its.hpecorp.net/display/HCSS/GLCP+API+standards+compliance+report+and+status

