### PR TITLE
Misc issues with api spec

### DIFF
--- a/v1/api/swagger/components/schemas/ProjectInfo.yaml
+++ b/v1/api/swagger/components/schemas/ProjectInfo.yaml
@@ -15,8 +15,8 @@ properties:
   Status:
     type: string
     enum:
-      - Enable
-      - Disable
+      - Enabled
+      - Disabled
   NumNetworks:
     type: integer
     description: Number of project networks

--- a/v1/api/swagger/paths/allocation@server.yaml
+++ b/v1/api/swagger/paths/allocation@server.yaml
@@ -6,7 +6,7 @@ get:
   operationId: allocation_getBySite
   parameters:
     - name: siteID
-      in: path
+      in: query
       description: site ID
       required: false
       schema:

--- a/v1/pkg/client/api/openapi.yaml
+++ b/v1/pkg/client/api/openapi.yaml
@@ -2290,7 +2290,7 @@ paths:
       operationId: allocation_getBySite
       parameters:
       - description: site ID
-        in: path
+        in: query
         name: siteID
         required: false
         schema:
@@ -2446,7 +2446,7 @@ components:
           OtherUsed: 3
           Name: Name
         Projects:
-        - Status: Enable
+        - Status: Enabled
           NumVolumes: 6
           Description: Description
           TotalStorageGB: 1
@@ -2461,7 +2461,7 @@ components:
           ID: ID
           NumNetworks: 5
           Name: Name
-        - Status: Enable
+        - Status: Enabled
           NumVolumes: 6
           Description: Description
           TotalStorageGB: 1
@@ -3294,7 +3294,7 @@ components:
       type: object
     ProjectInfo:
       example:
-        Status: Enable
+        Status: Enabled
         NumVolumes: 6
         Description: Description
         TotalStorageGB: 1
@@ -3324,8 +3324,8 @@ components:
           type: integer
         Status:
           enum:
-          - Enable
-          - Disable
+          - Enabled
+          - Disabled
           type: string
         NumNetworks:
           description: Number of project networks

--- a/v1/pkg/client/api_allocation.go
+++ b/v1/pkg/client/api_allocation.go
@@ -17,7 +17,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"strings"
 	"github.com/antihax/optional"
 )
 
@@ -29,14 +28,20 @@ var (
 // AllocationApiService AllocationApi service
 type AllocationApiService service
 
+// AllocationApiGetBySiteOpts Optional parameters for the method 'GetBySite'
+type AllocationApiGetBySiteOpts struct {
+    SiteID optional.String
+}
+
 /*
 GetBySite Get servers allocation
 Returns allocation information for each server instance type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param siteID site ID
+ * @param optional nil or *AllocationApiGetBySiteOpts - Optional Parameters:
+ * @param "SiteID" (optional.String) -  site ID
 @return Allocation
 */
-func (a *AllocationApiService) GetBySite(ctx _context.Context, siteID string) (Allocation, *_nethttp.Response, error) {
+func (a *AllocationApiService) GetBySite(ctx _context.Context, localVarOptionals *AllocationApiGetBySiteOpts) (Allocation, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -48,12 +53,13 @@ func (a *AllocationApiService) GetBySite(ctx _context.Context, siteID string) (A
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/allocation/servers"
-	localVarPath = strings.Replace(localVarPath, "{"+"siteID"+"}", _neturl.QueryEscape(parameterToString(siteID, "")) , -1)
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 
+	if localVarOptionals != nil && localVarOptionals.SiteID.IsSet() {
+		localVarQueryParams.Add("siteID", parameterToString(localVarOptionals.SiteID.Value(), ""))
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/v1/pkg/client/docs/AllocationApi.md
+++ b/v1/pkg/client/docs/AllocationApi.md
@@ -11,7 +11,7 @@ Method | HTTP request | Description
 
 ## GetBySite
 
-> Allocation GetBySite(ctx, siteID)
+> Allocation GetBySite(ctx, optional)
 
 Get servers allocation
 
@@ -23,7 +23,16 @@ Returns allocation information for each server instance type used by each PCE se
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**siteID** | **string**| site ID | 
+ **optional** | ***GetBySiteOpts** | optional parameters | nil if no parameters
+
+### Optional Parameters
+
+Optional parameters are passed through a pointer to a GetBySiteOpts struct
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **siteID** | **optional.String**| site ID | 
 
 ### Return type
 

--- a/v1/pkg/client/interface_allocation.go
+++ b/v1/pkg/client/interface_allocation.go
@@ -15,10 +15,11 @@ type AllocationAPI interface {
 	   GetBySite Get servers allocation
 	   Returns allocation information for each server instance type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
 	    * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	    * @param siteID site ID
+	    * @param optional nil or *AllocationApiGetBySiteOpts - Optional Parameters:
+	    * @param "SiteID" (optional.String) -  site ID
 	   @return Allocation
 	*/
-	GetBySite(ctx _context.Context, siteID string) (Allocation, *_nethttp.Response, error)
+	GetBySite(ctx _context.Context, localVarOptionals *AllocationApiGetBySiteOpts) (Allocation, *_nethttp.Response, error)
 	/*
 	   StorageGetBySite Get storage allocation
 	   Returns allocation information for each volume type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.

--- a/v1/pkg/mockquakeclient/mock_allocation.go
+++ b/v1/pkg/mockquakeclient/mock_allocation.go
@@ -39,9 +39,9 @@ func (m *MockAllocationAPI) EXPECT() *MockAllocationAPIMockRecorder {
 }
 
 // GetBySite mocks base method.
-func (m *MockAllocationAPI) GetBySite(ctx context.Context, siteID string) (client.Allocation, *http.Response, error) {
+func (m *MockAllocationAPI) GetBySite(ctx context.Context, localVarOptionals *client.AllocationApiGetBySiteOpts) (client.Allocation, *http.Response, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBySite", ctx, siteID)
+	ret := m.ctrl.Call(m, "GetBySite", ctx, localVarOptionals)
 	ret0, _ := ret[0].(client.Allocation)
 	ret1, _ := ret[1].(*http.Response)
 	ret2, _ := ret[2].(error)
@@ -49,9 +49,9 @@ func (m *MockAllocationAPI) GetBySite(ctx context.Context, siteID string) (clien
 }
 
 // GetBySite indicates an expected call of GetBySite.
-func (mr *MockAllocationAPIMockRecorder) GetBySite(ctx, siteID interface{}) *gomock.Call {
+func (mr *MockAllocationAPIMockRecorder) GetBySite(ctx, localVarOptionals interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBySite", reflect.TypeOf((*MockAllocationAPI)(nil).GetBySite), ctx, siteID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBySite", reflect.TypeOf((*MockAllocationAPI)(nil).GetBySite), ctx, localVarOptionals)
 }
 
 // StorageGetBySite mocks base method.


### PR DESCRIPTION
- Site ID isn't path parameter, it is query parameter
- corrected project status enum values to match with server-side values - https://github.com/hpe-hcss/quake/blob/8c2ecf2376a4bc10148f0ff262e92d6f770fd838/portal/api/project-rest/v1/model/project.go#L99