### PR TITLE
fix the return type of allocation apis

### DIFF
--- a/v1/api/swagger/paths/allocation@server.yaml
+++ b/v1/api/swagger/paths/allocation@server.yaml
@@ -2,7 +2,7 @@ get:
   tags:
     - allocation
   summary: Get servers allocation
-  description: Returns allocation information for each server instance type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
+  description: Returns an array of allocation information for each server instance type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
   operationId: allocation_getBySite
   parameters:
     - name: siteID
@@ -17,7 +17,9 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Allocation.yaml
+            items:
+              $ref: ../components/schemas/Allocation.yaml
+            type: array
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '500':

--- a/v1/api/swagger/paths/allocation@storage.yaml
+++ b/v1/api/swagger/paths/allocation@storage.yaml
@@ -2,7 +2,7 @@ get:
   tags:
     - allocation
   summary: Get storage allocation
-  description: Returns allocation information for each volume type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
+  description: Returns an array of allocation information for each volume type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
   operationId: allocation_storage_getBySite
   parameters:
     - name: siteID
@@ -17,7 +17,9 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/AllocationStorage.yaml
+            items:
+              $ref: ../components/schemas/AllocationStorage.yaml
+            type: array
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '500':

--- a/v1/pkg/client/api/openapi.yaml
+++ b/v1/pkg/client/api/openapi.yaml
@@ -2284,9 +2284,10 @@ paths:
     summary: Operations on a single IP pool
   /allocation/servers:
     get:
-      description: Returns allocation information for each server instance type used
-        by each PCE service. If siteID is present, the information returned is specific
-        to that site ID, otherwise the allocation information for all sites is returned.
+      description: Returns an array of allocation information for each server instance
+        type used by each PCE service. If siteID is present, the information returned
+        is specific to that site ID, otherwise the allocation information for all
+        sites is returned.
       operationId: allocation_getBySite
       parameters:
       - description: site ID
@@ -2300,7 +2301,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Allocation'
+                items:
+                  $ref: '#/components/schemas/Allocation'
+                type: array
           description: success
         "401":
           content:
@@ -2319,9 +2322,10 @@ paths:
       - allocation
   /allocation/storage:
     get:
-      description: Returns allocation information for each volume type used by each
-        PCE service. If siteID is present, the information returned is specific to
-        that site ID, otherwise the allocation information for all sites is returned.
+      description: Returns an array of allocation information for each volume type
+        used by each PCE service. If siteID is present, the information returned is
+        specific to that site ID, otherwise the allocation information for all sites
+        is returned.
       operationId: allocation_storage_getBySite
       parameters:
       - description: site ID
@@ -2335,7 +2339,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AllocationStorage'
+                items:
+                  $ref: '#/components/schemas/AllocationStorage'
+                type: array
           description: success
         "401":
           content:

--- a/v1/pkg/client/api_allocation.go
+++ b/v1/pkg/client/api_allocation.go
@@ -35,20 +35,20 @@ type AllocationApiGetBySiteOpts struct {
 
 /*
 GetBySite Get servers allocation
-Returns allocation information for each server instance type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
+Returns an array of allocation information for each server instance type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param optional nil or *AllocationApiGetBySiteOpts - Optional Parameters:
  * @param "SiteID" (optional.String) -  site ID
-@return Allocation
+@return []Allocation
 */
-func (a *AllocationApiService) GetBySite(ctx _context.Context, localVarOptionals *AllocationApiGetBySiteOpts) (Allocation, *_nethttp.Response, error) {
+func (a *AllocationApiService) GetBySite(ctx _context.Context, localVarOptionals *AllocationApiGetBySiteOpts) ([]Allocation, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		localVarReturnValue  Allocation
+		localVarReturnValue  []Allocation
 	)
 
 	// create path and map variables
@@ -123,7 +123,7 @@ func (a *AllocationApiService) GetBySite(ctx _context.Context, localVarOptionals
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
-			var v Allocation
+			var v []Allocation
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -173,20 +173,20 @@ type AllocationApiStorageGetBySiteOpts struct {
 
 /*
 StorageGetBySite Get storage allocation
-Returns allocation information for each volume type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
+Returns an array of allocation information for each volume type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param optional nil or *AllocationApiStorageGetBySiteOpts - Optional Parameters:
  * @param "SiteID" (optional.String) -  site ID
-@return AllocationStorage
+@return []AllocationStorage
 */
-func (a *AllocationApiService) StorageGetBySite(ctx _context.Context, localVarOptionals *AllocationApiStorageGetBySiteOpts) (AllocationStorage, *_nethttp.Response, error) {
+func (a *AllocationApiService) StorageGetBySite(ctx _context.Context, localVarOptionals *AllocationApiStorageGetBySiteOpts) ([]AllocationStorage, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		localVarReturnValue  AllocationStorage
+		localVarReturnValue  []AllocationStorage
 	)
 
 	// create path and map variables
@@ -261,7 +261,7 @@ func (a *AllocationApiService) StorageGetBySite(ctx _context.Context, localVarOp
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
-			var v AllocationStorage
+			var v []AllocationStorage
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()

--- a/v1/pkg/client/docs/AllocationApi.md
+++ b/v1/pkg/client/docs/AllocationApi.md
@@ -11,11 +11,11 @@ Method | HTTP request | Description
 
 ## GetBySite
 
-> Allocation GetBySite(ctx, optional)
+> []Allocation GetBySite(ctx, optional)
 
 Get servers allocation
 
-Returns allocation information for each server instance type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
+Returns an array of allocation information for each server instance type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
 
 ### Required Parameters
 
@@ -36,7 +36,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Allocation**](Allocation.md)
+[**[]Allocation**](Allocation.md)
 
 ### Authorization
 
@@ -54,11 +54,11 @@ Name | Type | Description  | Notes
 
 ## StorageGetBySite
 
-> AllocationStorage StorageGetBySite(ctx, optional)
+> []AllocationStorage StorageGetBySite(ctx, optional)
 
 Get storage allocation
 
-Returns allocation information for each volume type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
+Returns an array of allocation information for each volume type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
 
 ### Required Parameters
 
@@ -79,7 +79,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**AllocationStorage**](AllocationStorage.md)
+[**[]AllocationStorage**](AllocationStorage.md)
 
 ### Authorization
 

--- a/v1/pkg/client/interface_allocation.go
+++ b/v1/pkg/client/interface_allocation.go
@@ -13,20 +13,20 @@ import (
 type AllocationAPI interface {
 	/*
 	   GetBySite Get servers allocation
-	   Returns allocation information for each server instance type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
+	   Returns an array of allocation information for each server instance type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
 	    * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	    * @param optional nil or *AllocationApiGetBySiteOpts - Optional Parameters:
 	    * @param "SiteID" (optional.String) -  site ID
-	   @return Allocation
+	   @return []Allocation
 	*/
-	GetBySite(ctx _context.Context, localVarOptionals *AllocationApiGetBySiteOpts) (Allocation, *_nethttp.Response, error)
+	GetBySite(ctx _context.Context, localVarOptionals *AllocationApiGetBySiteOpts) ([]Allocation, *_nethttp.Response, error)
 	/*
 	   StorageGetBySite Get storage allocation
-	   Returns allocation information for each volume type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
+	   Returns an array of allocation information for each volume type used by each PCE service. If siteID is present, the information returned is specific to that site ID, otherwise the allocation information for all sites is returned.
 	    * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	    * @param optional nil or *AllocationApiStorageGetBySiteOpts - Optional Parameters:
 	    * @param "SiteID" (optional.String) -  site ID
-	   @return AllocationStorage
+	   @return []AllocationStorage
 	*/
-	StorageGetBySite(ctx _context.Context, localVarOptionals *AllocationApiStorageGetBySiteOpts) (AllocationStorage, *_nethttp.Response, error)
+	StorageGetBySite(ctx _context.Context, localVarOptionals *AllocationApiStorageGetBySiteOpts) ([]AllocationStorage, *_nethttp.Response, error)
 }

--- a/v1/pkg/mockquakeclient/mock_allocation.go
+++ b/v1/pkg/mockquakeclient/mock_allocation.go
@@ -39,10 +39,10 @@ func (m *MockAllocationAPI) EXPECT() *MockAllocationAPIMockRecorder {
 }
 
 // GetBySite mocks base method.
-func (m *MockAllocationAPI) GetBySite(ctx context.Context, localVarOptionals *client.AllocationApiGetBySiteOpts) (client.Allocation, *http.Response, error) {
+func (m *MockAllocationAPI) GetBySite(ctx context.Context, localVarOptionals *client.AllocationApiGetBySiteOpts) ([]client.Allocation, *http.Response, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBySite", ctx, localVarOptionals)
-	ret0, _ := ret[0].(client.Allocation)
+	ret0, _ := ret[0].([]client.Allocation)
 	ret1, _ := ret[1].(*http.Response)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -55,10 +55,10 @@ func (mr *MockAllocationAPIMockRecorder) GetBySite(ctx, localVarOptionals interf
 }
 
 // StorageGetBySite mocks base method.
-func (m *MockAllocationAPI) StorageGetBySite(ctx context.Context, localVarOptionals *client.AllocationApiStorageGetBySiteOpts) (client.AllocationStorage, *http.Response, error) {
+func (m *MockAllocationAPI) StorageGetBySite(ctx context.Context, localVarOptionals *client.AllocationApiStorageGetBySiteOpts) ([]client.AllocationStorage, *http.Response, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageGetBySite", ctx, localVarOptionals)
-	ret0, _ := ret[0].(client.AllocationStorage)
+	ret0, _ := ret[0].([]client.AllocationStorage)
 	ret1, _ := ret[1].(*http.Response)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2


### PR DESCRIPTION
The return type of allocation api was missing array of objects. 